### PR TITLE
Add 404 page mini-game experience

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Uy, esta nube se escapó | Petit Rêve</title>
+  <meta name="description" content="Página no encontrada. Probá el minijuego Saltito Nuboso y volvé a la tienda de Petit Rêve.">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body class="error-page">
+  <main class="error-page__content" role="main">
+    <section class="error-hero" aria-labelledby="error-title">
+      <div class="error-hero__text">
+        <p class="error-hero__code" aria-hidden="true">404</p>
+        <h1 id="error-title">Uy, la prenda que buscás está en otra nube</h1>
+        <p>Mientras la encontramos, jugá un rato con nuestro minijuego <strong>Saltito Nuboso</strong>. Saltá las cajas de telas y llegá lo más lejos que puedas.</p>
+        <div class="error-hero__actions">
+          <a class="btn btn-primary" href="index.html">Volver al inicio</a>
+          <button type="button" class="btn btn-secondary" id="error-game-start">Comenzar a jugar</button>
+        </div>
+      </div>
+      <div class="error-hero__mascot" aria-hidden="true">
+        <div class="error-cloud"></div>
+        <div class="error-balloon"></div>
+      </div>
+    </section>
+
+    <section class="error-game" aria-label="Minijuego Saltito Nuboso">
+      <div class="error-game__wrapper" role="application" aria-describedby="game-instructions">
+        <header class="error-game__hud">
+          <p id="game-instructions">Usá la barra espaciadora, la flecha hacia arriba o tocá la pantalla para saltar. Evitá los obstáculos y superá tu récord.</p>
+          <div class="error-game__scores" aria-live="polite" aria-atomic="true">
+            <span>Puntaje: <strong id="error-game-score">0</strong></span>
+            <span>Récord: <strong id="error-game-best">0</strong></span>
+          </div>
+        </header>
+        <canvas id="error-game-canvas" width="720" height="260" role="presentation" aria-hidden="true"></canvas>
+        <div class="error-game__message" id="error-game-message" role="status" aria-live="assertive"></div>
+      </div>
+    </section>
+  </main>
+  <footer class="error-footer">
+    <p>&copy; <span id="error-year"></span> Petit Rêve. Moda suave para peques felices.</p>
+  </footer>
+  <script src="error-game.js" defer></script>
+</body>
+</html>

--- a/error-game.js
+++ b/error-game.js
@@ -1,0 +1,329 @@
+(() => {
+  const canvas = document.getElementById('error-game-canvas');
+  const startButton = document.getElementById('error-game-start');
+  const scoreEl = document.getElementById('error-game-score');
+  const bestEl = document.getElementById('error-game-best');
+  const messageEl = document.getElementById('error-game-message');
+  const yearEl = document.getElementById('error-year');
+  const ctx = canvas ? canvas.getContext('2d') : null;
+
+  if (yearEl) {
+    yearEl.textContent = new Date().getFullYear().toString();
+  }
+
+  if (!canvas || !ctx) {
+    return;
+  }
+
+  const STORAGE_KEY = 'petitReve404BestScore';
+  const getBestFromStorage = () => {
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      return raw ? Number.parseInt(raw, 10) || 0 : 0;
+    } catch (error) {
+      return 0;
+    }
+  };
+
+  const setBestInStorage = (value) => {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, String(value));
+    } catch (error) {
+      /* noop */
+    }
+  };
+
+  const groundY = canvas.height - 50;
+  const player = {
+    width: 58,
+    height: 52,
+    x: 110,
+    y: groundY - 52,
+    vy: 0
+  };
+
+  const state = {
+    playing: false,
+    obstacles: [],
+    decorations: [],
+    score: 0,
+    best: getBestFromStorage(),
+    lastTime: 0,
+    nextSpawn: 0,
+    speed: 260
+  };
+
+  const randomBetween = (min, max) => Math.random() * (max - min) + min;
+
+  const createDecoration = () => ({
+    x: canvas.width + randomBetween(0, 200),
+    y: randomBetween(40, 120),
+    speed: randomBetween(22, 40),
+    scale: randomBetween(0.7, 1.3)
+  });
+
+  const resetPlayer = () => {
+    player.vy = 0;
+    player.y = groundY - player.height;
+  };
+
+  const scheduleNextSpawn = () => {
+    state.nextSpawn = randomBetween(0.9, 1.6);
+  };
+
+  const setMessage = (text, tone = 'neutral') => {
+    if (!messageEl) return;
+    messageEl.textContent = text;
+    messageEl.className = `error-game__message error-game__message--${tone}`;
+  };
+
+  const updateScoreDisplay = () => {
+    if (scoreEl) {
+      scoreEl.textContent = Math.floor(state.score).toString();
+    }
+    if (bestEl) {
+      bestEl.textContent = Math.floor(state.best).toString();
+    }
+  };
+
+  const resetGame = () => {
+    state.playing = false;
+    state.obstacles = [];
+    state.decorations = Array.from({ length: 3 }, createDecoration);
+    state.score = 0;
+    state.lastTime = 0;
+    scheduleNextSpawn();
+    resetPlayer();
+    updateScoreDisplay();
+    setMessage('Tocá "Comenzar a jugar" o presioná salto para empezar.');
+    drawScene(0);
+  };
+
+  const spawnObstacle = () => {
+    const height = randomBetween(36, 64);
+    const width = randomBetween(28, 46);
+    state.obstacles.push({
+      x: canvas.width + 10,
+      y: groundY - height,
+      width,
+      height,
+      colorShift: Math.random()
+    });
+  };
+
+  const startGame = () => {
+    if (state.playing) return;
+    state.playing = true;
+    state.score = 0;
+    state.obstacles = [];
+    state.decorations = Array.from({ length: 3 }, createDecoration);
+    state.lastTime = 0;
+    scheduleNextSpawn();
+    resetPlayer();
+    setMessage('¡A saltar! Evitá las cajas de telas.');
+  };
+
+  const endGame = () => {
+    state.playing = false;
+    if (state.score > state.best) {
+      state.best = state.score;
+      setBestInStorage(Math.floor(state.best));
+      setMessage(`Nuevo récord: ${Math.floor(state.score)} puntos. ¡Increíble!`, 'success');
+    } else {
+      setMessage(`¡Ups! Llegaste a ${Math.floor(state.score)} puntos. Probá otra vez.`, 'info');
+    }
+    updateScoreDisplay();
+  };
+
+  const jump = () => {
+    if (!state.playing) {
+      startGame();
+    }
+    const onGround = player.y >= groundY - player.height - 1;
+    if (onGround) {
+      player.vy = -420;
+    }
+  };
+
+  const isColliding = (rect) => {
+    return (
+      player.x < rect.x + rect.width &&
+      player.x + player.width > rect.x &&
+      player.y < rect.y + rect.height &&
+      player.y + player.height > rect.y
+    );
+  };
+
+  const drawRoundedRect = (x, y, width, height, radius) => {
+    const r = Math.min(radius, width / 2, height / 2);
+    ctx.beginPath();
+    ctx.moveTo(x + r, y);
+    ctx.lineTo(x + width - r, y);
+    ctx.quadraticCurveTo(x + width, y, x + width, y + r);
+    ctx.lineTo(x + width, y + height - r);
+    ctx.quadraticCurveTo(x + width, y + height, x + width - r, y + height);
+    ctx.lineTo(x + r, y + height);
+    ctx.quadraticCurveTo(x, y + height, x, y + height - r);
+    ctx.lineTo(x, y + r);
+    ctx.quadraticCurveTo(x, y, x + r, y);
+    ctx.closePath();
+    ctx.fill();
+  };
+
+  const drawCloud = (x, y, scale) => {
+    ctx.save();
+    ctx.translate(x, y);
+    ctx.scale(scale, scale);
+    ctx.fillStyle = 'rgba(255, 255, 255, 0.8)';
+    ctx.beginPath();
+    ctx.arc(-20, 0, 18, Math.PI * 0.5, Math.PI * 1.5);
+    ctx.arc(0, -18, 22, Math.PI, Math.PI * 1.85);
+    ctx.arc(28, -8, 16, Math.PI * 1.2, Math.PI * 1.9);
+    ctx.arc(30, 6, 20, Math.PI * 1.5, Math.PI * 0.5, true);
+    ctx.closePath();
+    ctx.fill();
+    ctx.restore();
+  };
+
+  const drawPlayer = () => {
+    ctx.save();
+    ctx.translate(player.x, player.y);
+    ctx.fillStyle = '#f7cfe0';
+    drawRoundedRect(0, 4, player.width, player.height - 4, 18);
+    ctx.fillStyle = '#ffffff';
+    drawRoundedRect(16, 0, 26, 24, 10);
+    ctx.fillStyle = '#44313c';
+    ctx.beginPath();
+    ctx.arc(26, 10, 3, 0, Math.PI * 2);
+    ctx.arc(34, 10, 3, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.fillRect(25, 18, 12, 3);
+    ctx.fillStyle = '#f2b6d1';
+    drawRoundedRect(10, player.height - 14, 18, 14, 6);
+    drawRoundedRect(player.width - 28, player.height - 14, 18, 14, 6);
+    ctx.restore();
+  };
+
+  const drawObstacle = (obstacle) => {
+    const { x, y, width, height, colorShift } = obstacle;
+    const hue = 330 + colorShift * 40;
+    ctx.fillStyle = `hsl(${hue}, 65%, 70%)`;
+    drawRoundedRect(x, y, width, height, 8);
+    ctx.fillStyle = `hsl(${hue}, 65%, 62%)`;
+    ctx.fillRect(x + 6, y + height - 14, width - 12, 8);
+  };
+
+  const drawGround = () => {
+    ctx.fillStyle = '#fbe9f2';
+    ctx.fillRect(0, groundY, canvas.width, canvas.height - groundY);
+    ctx.strokeStyle = '#f2b6d1';
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.moveTo(0, groundY);
+    ctx.lineTo(canvas.width, groundY);
+    ctx.stroke();
+    ctx.lineWidth = 1;
+    ctx.setLineDash([10, 14]);
+    ctx.strokeStyle = 'rgba(68, 49, 60, 0.15)';
+    ctx.beginPath();
+    ctx.moveTo(0, groundY + 16);
+    ctx.lineTo(canvas.width, groundY + 16);
+    ctx.stroke();
+    ctx.setLineDash([]);
+  };
+
+  const drawBackground = (time) => {
+    ctx.fillStyle = '#fdf7fb';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    const gradient = ctx.createLinearGradient(0, 0, 0, canvas.height);
+    gradient.addColorStop(0, '#fdf7fb');
+    gradient.addColorStop(1, '#f5eaf5');
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+    state.decorations.forEach((cloud) => {
+      drawCloud(cloud.x, cloud.y, cloud.scale);
+    });
+  };
+
+  const drawScene = (time) => {
+    drawBackground(time);
+    drawGround();
+    state.obstacles.forEach(drawObstacle);
+    drawPlayer();
+  };
+
+  const update = (time) => {
+    const now = time || performance.now();
+    let delta = 0;
+    if (state.lastTime) {
+      delta = (now - state.lastTime) / 1000;
+      if (delta > 0.05) {
+        delta = 0.05;
+      }
+    }
+    state.lastTime = now;
+
+    if (state.playing) {
+      state.score += delta * 60;
+      updateScoreDisplay();
+
+      player.vy += 1200 * delta;
+      player.y += player.vy * delta;
+      if (player.y > groundY - player.height) {
+        player.y = groundY - player.height;
+        player.vy = 0;
+      }
+
+      state.obstacles.forEach((obstacle) => {
+        obstacle.x -= state.speed * delta;
+      });
+      state.obstacles = state.obstacles.filter((obstacle) => obstacle.x + obstacle.width > -5);
+
+      state.decorations.forEach((cloud, index) => {
+        cloud.x -= cloud.speed * delta;
+        if (cloud.x < -80) {
+          state.decorations[index] = createDecoration();
+        }
+      });
+
+      state.nextSpawn -= delta;
+      if (state.nextSpawn <= 0) {
+        spawnObstacle();
+        scheduleNextSpawn();
+      }
+
+      const hasCollision = state.obstacles.some(isColliding);
+      if (hasCollision) {
+        endGame();
+      }
+    }
+
+    drawScene(now);
+    window.requestAnimationFrame(update);
+  };
+
+  const handleKeydown = (event) => {
+    if (['Space', 'ArrowUp', 'KeyW'].includes(event.code)) {
+      event.preventDefault();
+      jump();
+    }
+  };
+
+  const handlePointer = (event) => {
+    event.preventDefault();
+    jump();
+  };
+
+  if (startButton) {
+    startButton.addEventListener('click', startGame);
+  }
+
+  window.addEventListener('keydown', handleKeydown);
+  canvas.addEventListener('pointerdown', handlePointer);
+  canvas.addEventListener('touchstart', handlePointer);
+
+  updateScoreDisplay();
+  resetGame();
+  window.requestAnimationFrame(update);
+})();

--- a/styles.css
+++ b/styles.css
@@ -1036,3 +1036,224 @@ body.mini-game-open {
     grid-template-columns: repeat(4, minmax(0, 1fr));
   }
 }
+
+/* 404 Error page */
+body.error-page {
+  background: radial-gradient(circle at top, rgba(247, 207, 224, 0.35), transparent 55%), var(--color-bg);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  color: var(--color-text);
+}
+
+.error-page__content {
+  flex: 1;
+  width: min(100% - 2rem, 1100px);
+  margin: 0 auto;
+  padding: 3rem 0 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+}
+
+.error-hero {
+  background: rgba(255, 255, 255, 0.82);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-soft);
+  padding: clamp(2rem, 5vw, 3rem);
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: clamp(1.5rem, 4vw, 3rem);
+  align-items: center;
+}
+
+.error-hero__text h1 {
+  margin-top: 0;
+  font-size: clamp(1.9rem, 3vw, 2.6rem);
+}
+
+.error-hero__text p {
+  margin-bottom: 1.5rem;
+  color: var(--color-muted);
+}
+
+.error-hero__code {
+  font-size: clamp(2.6rem, 6vw, 4rem);
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  margin: 0 0 0.75rem;
+  color: var(--color-primary-dark);
+}
+
+.error-hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.error-hero__mascot {
+  position: relative;
+  height: 220px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.error-cloud,
+.error-balloon {
+  position: absolute;
+  border-radius: 50%;
+}
+
+.error-cloud {
+  width: 220px;
+  height: 140px;
+  background: radial-gradient(circle at 30% 30%, #ffffff, rgba(255, 255, 255, 0.7));
+  filter: drop-shadow(0 20px 30px rgba(68, 49, 60, 0.08));
+}
+
+.error-cloud::before,
+.error-cloud::after {
+  content: "";
+  position: absolute;
+  background: inherit;
+  border-radius: 50%;
+}
+
+.error-cloud::before {
+  width: 120px;
+  height: 120px;
+  top: -40px;
+  left: 15px;
+}
+
+.error-cloud::after {
+  width: 140px;
+  height: 140px;
+  top: -20px;
+  right: 0;
+}
+
+.error-balloon {
+  width: 90px;
+  height: 120px;
+  background: radial-gradient(circle at 30% 20%, #ffe7b3, #f9c573);
+  animation: float 6s ease-in-out infinite;
+}
+
+.error-balloon::after {
+  content: "";
+  position: absolute;
+  bottom: -35px;
+  left: 50%;
+  width: 4px;
+  height: 40px;
+  background: rgba(249, 197, 115, 0.7);
+  transform: translateX(-50%);
+}
+
+@keyframes float {
+  0%,
+  100% {
+    transform: translate(-40px, -10px);
+  }
+  50% {
+    transform: translate(20px, 10px);
+  }
+}
+
+.error-game {
+  background: rgba(255, 255, 255, 0.85);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-soft);
+  padding: clamp(2rem, 5vw, 3rem);
+}
+
+.error-game__wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.error-game__hud {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  color: var(--color-muted);
+}
+
+.error-game__scores {
+  display: inline-flex;
+  gap: 1.5rem;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+#error-game-canvas {
+  width: 100%;
+  max-width: 720px;
+  border-radius: 16px;
+  background: #fdf7fb;
+  border: 2px solid rgba(68, 49, 60, 0.08);
+  align-self: center;
+}
+
+.error-game__message {
+  min-height: 1.5rem;
+  text-align: center;
+  font-weight: 600;
+  color: var(--color-muted);
+}
+
+.error-game__message--success {
+  color: #3b8a4a;
+}
+
+.error-game__message--info {
+  color: #325f9b;
+}
+
+.error-footer {
+  text-align: center;
+  padding: 2rem 1rem 3rem;
+  color: rgba(68, 49, 60, 0.7);
+  font-size: 0.95rem;
+}
+
+@media (max-width: 900px) {
+  .error-hero {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+
+  .error-hero__actions {
+    justify-content: center;
+  }
+
+  .error-hero__mascot {
+    order: -1;
+    height: 200px;
+  }
+}
+
+@media (max-width: 600px) {
+  .error-page__content {
+    padding: 2rem 0 1rem;
+  }
+
+  .error-game__hud {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .error-game__scores {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .error-game__wrapper {
+    gap: 0.75rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated 404 page with Saltito Nuboso messaging and calls to action
- implement a canvas-based endless runner mini-game with scoring and local high score tracking
- style the error page and game wrapper to match the site's playful brand and remain responsive

## Testing
- Manually opened 404.html in the browser

------
https://chatgpt.com/codex/tasks/task_e_68dc86691ce083328e9ae558226247b9