### PR TITLE
Create browser-only SPA for product and ingredient costing

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,1125 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Gestor de Costos</title>
+  <style>
+    :root {
+      --bg: #f7f7fb;
+      --card: #ffffff;
+      --text: #1f2937;
+      --muted: #6b7280;
+      --primary: #2563eb;
+      --accent: #10b981;
+      --danger: #ef4444;
+      --border: #e5e7eb;
+      --radius: 12px;
+      --shadow: 0 6px 20px rgba(0, 0, 0, 0.06);
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    h1, h2, h3, h4 {
+      margin: 0;
+      font-weight: 600;
+    }
+
+    button {
+      font: inherit;
+      cursor: pointer;
+    }
+
+    .app-header {
+      padding: 16px 24px;
+      background: var(--card);
+      border-bottom: 1px solid var(--border);
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      position: sticky;
+      top: 0;
+      z-index: 10;
+    }
+
+    .header-actions {
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .btn {
+      padding: 8px 16px;
+      border-radius: 999px;
+      border: 1px solid transparent;
+      font-weight: 600;
+      transition: background 0.2s ease, transform 0.1s ease, box-shadow 0.2s ease;
+    }
+
+    .btn-primary {
+      background: var(--primary);
+      color: #fff;
+      box-shadow: 0 4px 12px rgba(37, 99, 235, 0.24);
+    }
+
+    .btn-secondary {
+      background: #fff;
+      color: var(--primary);
+      border-color: var(--primary);
+    }
+
+    .btn-danger {
+      background: var(--danger);
+      color: #fff;
+      box-shadow: 0 4px 12px rgba(239, 68, 68, 0.24);
+    }
+
+    .btn:focus-visible {
+      outline: 2px solid var(--primary);
+      outline-offset: 2px;
+    }
+
+    .btn:active {
+      transform: translateY(1px);
+    }
+
+    .layout {
+      flex: 1;
+      display: grid;
+      grid-template-columns: 320px 1fr 320px;
+      gap: 16px;
+      padding: 16px 24px 32px;
+    }
+
+    .card {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      box-shadow: var(--shadow);
+      padding: 20px;
+    }
+
+    .sidebar-title {
+      font-size: 1.1rem;
+      margin-bottom: 16px;
+    }
+
+    .search-input {
+      width: 100%;
+      padding: 10px 14px;
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      font: inherit;
+    }
+
+    .search-input:focus {
+      outline: 2px solid var(--primary);
+      outline-offset: 2px;
+    }
+
+    .product-list {
+      margin: 16px 0;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      max-height: calc(100vh - 260px);
+      overflow-y: auto;
+      padding-right: 4px;
+    }
+
+    .product-item {
+      padding: 12px 16px;
+      border-radius: var(--radius);
+      border: 1px solid transparent;
+      background: #fff;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      transition: transform 0.1s ease, box-shadow 0.2s ease, border 0.2s ease;
+    }
+
+    .product-item:hover {
+      box-shadow: var(--shadow);
+      transform: translateY(-1px);
+    }
+
+    .product-item.active {
+      border-color: var(--primary);
+      box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.15);
+    }
+
+    .product-item .cost {
+      color: var(--muted);
+      font-weight: 500;
+    }
+
+    .section-title {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      margin-bottom: 20px;
+    }
+
+    .stats-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 16px;
+      margin-bottom: 24px;
+    }
+
+    .stat-card {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .stat-title {
+      color: var(--muted);
+      font-size: 0.9rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+
+    .stat-value {
+      font-size: 1.6rem;
+      font-weight: 700;
+    }
+
+    .form-grid {
+      display: grid;
+      gap: 12px;
+    }
+
+    .form-row {
+      display: grid;
+      gap: 8px;
+    }
+
+    label {
+      font-size: 0.85rem;
+      color: var(--muted);
+    }
+
+    input, select {
+      width: 100%;
+      padding: 10px 12px;
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      font: inherit;
+      background: #fff;
+    }
+
+    input:focus, select:focus {
+      outline: 2px solid var(--primary);
+      outline-offset: 2px;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      overflow: hidden;
+      border-radius: var(--radius);
+    }
+
+    thead {
+      background: #eef2ff;
+      color: #1e3a8a;
+      position: sticky;
+      top: 0;
+      z-index: 1;
+    }
+
+    th, td {
+      text-align: left;
+      padding: 12px;
+      font-size: 0.92rem;
+    }
+
+    tbody tr:nth-child(even) {
+      background: #fafafa;
+    }
+
+    tbody tr:hover {
+      background: #f1f5f9;
+    }
+
+    .table-wrapper {
+      max-height: 280px;
+      overflow-y: auto;
+      border-radius: var(--radius);
+      border: 1px solid var(--border);
+    }
+
+    .table-actions {
+      display: flex;
+      gap: 8px;
+    }
+
+    .tag {
+      display: inline-flex;
+      align-items: center;
+      background: rgba(37, 99, 235, 0.1);
+      color: var(--primary);
+      padding: 4px 8px;
+      border-radius: 999px;
+      font-size: 0.75rem;
+      font-weight: 600;
+    }
+
+    .component-form {
+      margin-top: 16px;
+      display: grid;
+      grid-template-columns: 2fr 1fr auto;
+      gap: 12px;
+      align-items: end;
+    }
+
+    .component-form button {
+      white-space: nowrap;
+    }
+
+    .message {
+      font-size: 0.82rem;
+      margin-top: 8px;
+      color: var(--danger);
+      min-height: 18px;
+    }
+
+    .muted {
+      color: var(--muted);
+      font-size: 0.88rem;
+    }
+
+    .empty-state {
+      padding: 40px;
+      text-align: center;
+      color: var(--muted);
+      border: 2px dashed var(--border);
+      border-radius: var(--radius);
+    }
+
+    .mobile-tabs {
+      display: none;
+      padding: 8px;
+      background: var(--card);
+      border-bottom: 1px solid var(--border);
+      gap: 8px;
+    }
+
+    .mobile-tabs button {
+      flex: 1;
+      padding: 10px;
+      border-radius: 10px;
+      border: 1px solid var(--border);
+      background: #fff;
+      font-weight: 600;
+    }
+
+    .mobile-tabs button.active {
+      background: var(--primary);
+      color: #fff;
+      border-color: transparent;
+    }
+
+    @media (max-width: 1080px) {
+      .layout {
+        grid-template-columns: 280px 1fr;
+      }
+    }
+
+    @media (max-width: 900px) {
+      .layout {
+        display: flex;
+        flex-direction: column;
+        padding: 16px;
+      }
+
+      .mobile-tabs {
+        display: flex;
+        position: sticky;
+        top: 64px;
+        z-index: 9;
+      }
+
+      .panel {
+        display: none;
+      }
+
+      .panel.active {
+        display: block;
+      }
+
+      .table-wrapper {
+        max-height: none;
+      }
+
+      thead {
+        position: sticky;
+        top: 0;
+      }
+
+      .component-form {
+        grid-template-columns: 1fr;
+      }
+    }
+
+    .toast {
+      position: fixed;
+      bottom: 24px;
+      right: 24px;
+      background: var(--card);
+      padding: 16px 20px;
+      border-radius: var(--radius);
+      box-shadow: var(--shadow);
+      border: 1px solid var(--border);
+      display: none;
+    }
+
+    .toast.show {
+      display: block;
+    }
+  </style>
+</head>
+<body>
+  <header class="app-header">
+    <h1>Gestor de Costos</h1>
+    <div class="header-actions">
+      <button class="btn btn-secondary" id="exportBtn">Exportar JSON</button>
+      <label class="btn btn-secondary" for="importInput" role="button">Importar JSON</label>
+      <input type="file" id="importInput" accept="application/json" hidden />
+      <button class="btn btn-danger" id="resetBtn">Reiniciar</button>
+    </div>
+  </header>
+
+  <div class="mobile-tabs" id="mobileTabs">
+    <button data-target="productos" class="active">Productos</button>
+    <button data-target="detalle">Detalle</button>
+    <button data-target="ingredientes">Ingredientes</button>
+  </div>
+
+  <main class="layout">
+    <section class="card panel" id="productosPanel">
+      <div class="section-title">
+        <h2 class="sidebar-title">Productos</h2>
+        <div class="table-actions" style="gap:8px;">
+          <button class="btn btn-secondary" id="duplicateProductBtn">Duplicar</button>
+          <button class="btn btn-danger" id="deleteProductBtn">Eliminar</button>
+        </div>
+      </div>
+      <input type="search" class="search-input" id="productSearch" placeholder="Buscar producto" aria-label="Buscar producto" />
+      <div class="product-list" id="productList" role="listbox" aria-label="Lista de productos"></div>
+      <button class="btn btn-primary" id="newProductBtn" style="width:100%; margin-top:auto;">Nuevo producto</button>
+    </section>
+
+    <section class="card panel" id="detallePanel">
+      <div class="section-title">
+        <h2>Detalle del producto</h2>
+        <span class="tag" id="detalleTag">Sin seleccionar</span>
+      </div>
+      <div id="productDetail"></div>
+    </section>
+
+    <section class="card panel" id="ingredientesPanel">
+      <div class="section-title">
+        <h2 class="sidebar-title">Ingredientes</h2>
+      </div>
+      <div class="table-wrapper" aria-live="polite">
+        <table>
+          <thead>
+            <tr>
+              <th>Nombre</th>
+              <th>Unidad</th>
+              <th>Costo/u</th>
+            </tr>
+          </thead>
+          <tbody id="ingredientsTable"></tbody>
+        </table>
+      </div>
+      <form id="ingredientForm" class="form-grid" autocomplete="off">
+        <input type="hidden" id="ingredientId" />
+        <div class="form-row">
+          <label for="ingredientName">Nombre</label>
+          <input type="text" id="ingredientName" required />
+        </div>
+        <div class="form-row">
+          <label for="ingredientUnit">Unidad</label>
+          <input type="text" id="ingredientUnit" placeholder="g, ml, u" />
+        </div>
+        <div class="form-row">
+          <label for="ingredientCost">Costo por unidad</label>
+          <input type="text" id="ingredientCost" required />
+        </div>
+        <div class="table-actions" style="margin-top:8px;">
+          <button type="submit" class="btn btn-primary" id="ingredientSaveBtn">Guardar ingrediente</button>
+          <button type="button" class="btn btn-secondary" id="ingredientClearBtn">Limpiar</button>
+          <button type="button" class="btn btn-danger" id="ingredientDeleteBtn" disabled>Eliminar</button>
+        </div>
+        <div class="message" id="ingredientMessage" role="alert" aria-live="polite"></div>
+      </form>
+    </section>
+  </main>
+
+  <div class="toast" id="toast" role="status" aria-live="polite"></div>
+
+  <script type="module">
+    const STORAGE_KEY = 'costosApp';
+    const seed = {
+      ingredientes: [
+        { id: 'ing-harina', nombre: 'Harina', unidad: 'g', costo_por_unidad: 0.002 },
+        { id: 'ing-queso', nombre: 'Queso', unidad: 'g', costo_por_unidad: 0.007 },
+        { id: 'ing-salsa', nombre: 'Salsa', unidad: 'g', costo_por_unidad: 0.0012 }
+      ],
+      productos: [
+        {
+          id: 'prod-pizza-muzza',
+          nombre: 'Pizza Muzza',
+          unidad_salida: 'u',
+          cantidad_salida: 1,
+          componentes: [
+            { ingrediente_id: 'ing-harina', cantidad_uso: 250 },
+            { ingrediente_id: 'ing-queso', cantidad_uso: 200 },
+            { ingrediente_id: 'ing-salsa', cantidad_uso: 80 }
+          ]
+        }
+      ],
+      seleccionado: { productoId: 'prod-pizza-muzza' }
+    };
+
+    let state = loadState();
+    let saveTimer = null;
+
+    function uid() {
+      return 'id-' + Math.random().toString(36).slice(2, 10) + '-' + Date.now().toString(36);
+    }
+
+    function parseNumber(value) {
+      if (typeof value !== 'string' && typeof value !== 'number') return null;
+      const normalized = String(value).replace(/,/g, '.').trim();
+      if (normalized === '') return null;
+      const num = Number(normalized);
+      return Number.isFinite(num) ? num : null;
+    }
+
+    const moneyFormatter = new Intl.NumberFormat('es-AR', {
+      style: 'currency',
+      currency: 'ARS',
+      minimumFractionDigits: 2
+    });
+
+    function formatMoney(value) {
+      return moneyFormatter.format(value || 0);
+    }
+
+    function loadState() {
+      try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        if (!raw) {
+          return JSON.parse(JSON.stringify(seed));
+        }
+        const parsed = JSON.parse(raw);
+        return {
+          ingredientes: Array.isArray(parsed.ingredientes) ? parsed.ingredientes : [],
+          productos: Array.isArray(parsed.productos) ? parsed.productos : [],
+          seleccionado: parsed.seleccionado || { productoId: null }
+        };
+      } catch (error) {
+        console.error('Error cargando estado', error);
+        return JSON.parse(JSON.stringify(seed));
+      }
+    }
+
+    function scheduleSave() {
+      if (saveTimer) {
+        clearTimeout(saveTimer);
+      }
+      saveTimer = setTimeout(() => {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+      }, 300);
+    }
+
+    function setState(updater) {
+      const nextState = typeof updater === 'function' ? updater(state) : updater;
+      state = nextState;
+      scheduleSave();
+      render();
+    }
+
+    function updateState(partial) {
+      setState({ ...state, ...partial });
+    }
+
+    function costoTanda(producto, ingredientesMap) {
+      if (!producto) return 0;
+      return producto.componentes.reduce((acc, comp) => {
+        const ing = ingredientesMap.get(comp.ingrediente_id);
+        if (!ing) return acc;
+        return acc + comp.cantidad_uso * ing.costo_por_unidad;
+      }, 0);
+    }
+
+    function costoUnidad(producto, ingredientesMap) {
+      const tanda = costoTanda(producto, ingredientesMap);
+      const salida = Math.max(parseNumber(producto?.cantidad_salida) || 0, 1);
+      return tanda / salida;
+    }
+
+    function showToast(message, type = 'info') {
+      const toast = document.getElementById('toast');
+      toast.textContent = message;
+      toast.style.borderColor = type === 'error' ? 'var(--danger)' : 'var(--border)';
+      toast.style.color = type === 'error' ? 'var(--danger)' : 'inherit';
+      toast.classList.add('show');
+      setTimeout(() => toast.classList.remove('show'), 2500);
+    }
+
+    function selectProduct(productId) {
+      updateState({ seleccionado: { productoId } });
+    }
+
+    function getSelectedProduct() {
+      return state.productos.find((p) => p.id === state.seleccionado?.productoId) || null;
+    }
+
+    function renderProductsList() {
+      const list = document.getElementById('productList');
+      list.innerHTML = '';
+      const search = document.getElementById('productSearch').value.trim().toLowerCase();
+      const ingredientsMap = new Map(state.ingredientes.map((ing) => [ing.id, ing]));
+      const filtered = state.productos.filter((prod) => prod.nombre.toLowerCase().includes(search));
+      if (!filtered.length) {
+        const empty = document.createElement('div');
+        empty.className = 'empty-state';
+        empty.textContent = 'No hay productos. Crea uno nuevo para comenzar.';
+        list.appendChild(empty);
+        return;
+      }
+      filtered.forEach((prod) => {
+        const item = document.createElement('button');
+        item.type = 'button';
+        item.className = 'product-item' + (prod.id === state.seleccionado?.productoId ? ' active' : '');
+        item.setAttribute('role', 'option');
+        item.setAttribute('aria-selected', prod.id === state.seleccionado?.productoId);
+        const left = document.createElement('div');
+        left.innerHTML = `<strong>${prod.nombre}</strong>`;
+        const cost = document.createElement('div');
+        cost.className = 'cost';
+        cost.textContent = formatMoney(costoUnidad(prod, ingredientsMap));
+        item.append(left, cost);
+        item.addEventListener('click', () => selectProduct(prod.id));
+        list.appendChild(item);
+      });
+    }
+
+    function renderProductDetail() {
+      const container = document.getElementById('productDetail');
+      const tag = document.getElementById('detalleTag');
+      const product = getSelectedProduct();
+      if (!product) {
+        tag.textContent = 'Sin seleccionar';
+        container.innerHTML = '<div class="empty-state">Selecciona o crea un producto para ver sus detalles.</div>';
+        return;
+      }
+      tag.textContent = product.nombre;
+      const ingredientsMap = new Map(state.ingredientes.map((ing) => [ing.id, ing]));
+      const tanda = costoTanda(product, ingredientsMap);
+      const unidad = costoUnidad(product, ingredientsMap);
+
+      container.innerHTML = `
+        <form id="productForm" class="form-grid" autocomplete="off">
+          <div class="form-row">
+            <label for="productName">Nombre</label>
+            <input type="text" id="productName" value="${product.nombre}" required />
+          </div>
+          <div class="form-row">
+            <label for="productUnit">Unidad de salida</label>
+            <input type="text" id="productUnit" value="${product.unidad_salida || ''}" />
+          </div>
+          <div class="form-row">
+            <label for="productOutput">Cantidad de salida</label>
+            <input type="number" id="productOutput" value="${product.cantidad_salida}" min="1" />
+          </div>
+        </form>
+        <div class="stats-grid" aria-live="polite">
+          <div class="card stat-card">
+            <span class="stat-title">Costo de la tanda</span>
+            <span class="stat-value">${formatMoney(tanda)}</span>
+          </div>
+          <div class="card stat-card">
+            <span class="stat-title">Costo por unidad</span>
+            <span class="stat-value">${formatMoney(unidad)}</span>
+          </div>
+        </div>
+        <div class="table-wrapper" aria-live="polite">
+          <table>
+            <thead>
+              <tr>
+                <th>Ingrediente</th>
+                <th>Unidad</th>
+                <th>Costo/u</th>
+                <th>Cantidad</th>
+                <th>Costo línea</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody id="componentsTable"></tbody>
+          </table>
+        </div>
+        <form id="componentForm" class="component-form" autocomplete="off">
+          <div>
+            <label for="componentIngredient">Ingrediente</label>
+            <select id="componentIngredient" required>
+              <option value="">Selecciona ingrediente</option>
+              ${state.ingredientes
+                .map((ing) => `<option value="${ing.id}">${ing.nombre}</option>`)
+                .join('')}
+            </select>
+          </div>
+          <div>
+            <label for="componentQuantity">Cantidad</label>
+            <input type="text" id="componentQuantity" placeholder="0" required />
+          </div>
+          <button type="submit" class="btn btn-primary">Agregar / Actualizar</button>
+          <div class="message" id="componentMessage"></div>
+        </form>
+      `;
+
+      const productForm = document.getElementById('productForm');
+      productForm.addEventListener('input', handleProductFormChange);
+      productForm.addEventListener('submit', (e) => e.preventDefault());
+
+      const componentsTable = document.getElementById('componentsTable');
+      componentsTable.innerHTML = '';
+      product.componentes.forEach((comp) => {
+        const ing = ingredientsMap.get(comp.ingrediente_id);
+        const tr = document.createElement('tr');
+        const nombre = ing ? ing.nombre : 'Ingrediente eliminado';
+        const unidadIng = ing ? ing.unidad : '-';
+        const costoIng = ing ? formatMoney(ing.costo_por_unidad) : '-';
+        const costoLinea = ing ? formatMoney(comp.cantidad_uso * ing.costo_por_unidad) : '-';
+        tr.innerHTML = `
+          <td>${nombre}</td>
+          <td>${unidadIng}</td>
+          <td>${costoIng}</td>
+          <td>
+            <input type="number" min="0" step="any" class="component-quantity" data-id="${comp.ingrediente_id}" value="${comp.cantidad_uso}" />
+          </td>
+          <td>${costoLinea}</td>
+          <td><button type="button" class="btn btn-danger btn-sm" data-remove="${comp.ingrediente_id}">Eliminar</button></td>
+        `;
+        componentsTable.appendChild(tr);
+      });
+
+      componentsTable.querySelectorAll('.component-quantity').forEach((input) => {
+        input.addEventListener('change', (event) => {
+          const id = event.target.dataset.id;
+          const value = parseNumber(event.target.value);
+          if (value === null || value < 0) {
+            showToast('La cantidad debe ser un número mayor o igual a 0', 'error');
+            event.target.value = product.componentes.find((c) => c.ingrediente_id === id)?.cantidad_uso || 0;
+            return;
+          }
+          updateComponentQuantity(product.id, id, value);
+        });
+      });
+
+      componentsTable.querySelectorAll('[data-remove]').forEach((btn) => {
+        btn.addEventListener('click', () => {
+          removeComponent(product.id, btn.dataset.remove);
+        });
+      });
+
+      const componentForm = document.getElementById('componentForm');
+      componentForm.addEventListener('submit', handleComponentSubmit);
+      componentForm.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape') {
+          componentForm.reset();
+          document.getElementById('componentMessage').textContent = '';
+        }
+      });
+    }
+
+    function handleProductFormChange(event) {
+      const product = getSelectedProduct();
+      if (!product) return;
+      const name = document.getElementById('productName').value.trim();
+      const unidad = document.getElementById('productUnit').value.trim();
+      const cantidadRaw = document.getElementById('productOutput').value;
+      const cantidad = Math.max(parseInt(cantidadRaw, 10) || 1, 1);
+      updateState({
+        productos: state.productos.map((p) =>
+          p.id === product.id
+            ? { ...p, nombre: name || 'Sin nombre', unidad_salida: unidad, cantidad_salida: cantidad }
+            : p
+        )
+      });
+    }
+
+    function handleComponentSubmit(event) {
+      event.preventDefault();
+      const product = getSelectedProduct();
+      if (!product) return;
+      const ingredientId = document.getElementById('componentIngredient').value;
+      const quantityStr = document.getElementById('componentQuantity').value;
+      const messageEl = document.getElementById('componentMessage');
+      messageEl.textContent = '';
+      const quantity = parseNumber(quantityStr);
+      if (!ingredientId) {
+        messageEl.textContent = 'Selecciona un ingrediente válido';
+        return;
+      }
+      if (quantity === null || quantity < 0) {
+        messageEl.textContent = 'La cantidad debe ser un número mayor o igual a 0';
+        return;
+      }
+      addOrUpdateComponent(product.id, ingredientId, quantity);
+      event.target.reset();
+      showToast('Componente actualizado');
+    }
+
+    function updateComponentQuantity(productId, ingredientId, quantity) {
+      updateState({
+        productos: state.productos.map((prod) => {
+          if (prod.id !== productId) return prod;
+          return {
+            ...prod,
+            componentes: prod.componentes.map((comp) =>
+              comp.ingrediente_id === ingredientId ? { ...comp, cantidad_uso: quantity } : comp
+            )
+          };
+        })
+      });
+    }
+
+    function addOrUpdateComponent(productId, ingredientId, quantity) {
+      updateState({
+        productos: state.productos.map((prod) => {
+          if (prod.id !== productId) return prod;
+          const existing = prod.componentes.find((c) => c.ingrediente_id === ingredientId);
+          if (existing) {
+            return {
+              ...prod,
+              componentes: prod.componentes.map((c) =>
+                c.ingrediente_id === ingredientId ? { ...c, cantidad_uso: quantity } : c
+              )
+            };
+          }
+          return {
+            ...prod,
+            componentes: [...prod.componentes, { ingrediente_id: ingredientId, cantidad_uso: quantity }]
+          };
+        })
+      });
+    }
+
+    function removeComponent(productId, ingredientId) {
+      updateState({
+        productos: state.productos.map((prod) =>
+          prod.id === productId
+            ? { ...prod, componentes: prod.componentes.filter((c) => c.ingrediente_id !== ingredientId) }
+            : prod
+        )
+      });
+      showToast('Ingrediente quitado del producto');
+    }
+
+    function renderIngredients() {
+      const tbody = document.getElementById('ingredientsTable');
+      tbody.innerHTML = '';
+      if (!state.ingredientes.length) {
+        const tr = document.createElement('tr');
+        const td = document.createElement('td');
+        td.colSpan = 3;
+        td.className = 'muted';
+        td.textContent = 'Aún no hay ingredientes';
+        tr.appendChild(td);
+        tbody.appendChild(tr);
+        return;
+      }
+
+      state.ingredientes.forEach((ing) => {
+        const tr = document.createElement('tr');
+        tr.tabIndex = 0;
+        tr.innerHTML = `
+          <td>${ing.nombre}</td>
+          <td>${ing.unidad || '-'}</td>
+          <td>${formatMoney(ing.costo_por_unidad)}</td>
+        `;
+        tr.addEventListener('click', () => populateIngredientForm(ing.id));
+        tr.addEventListener('keypress', (event) => {
+          if (event.key === 'Enter') {
+            populateIngredientForm(ing.id);
+          }
+        });
+        tbody.appendChild(tr);
+      });
+    }
+
+    function populateIngredientForm(id) {
+      const ing = state.ingredientes.find((item) => item.id === id);
+      if (!ing) return;
+      document.getElementById('ingredientId').value = ing.id;
+      document.getElementById('ingredientName').value = ing.nombre;
+      document.getElementById('ingredientUnit').value = ing.unidad || '';
+      document.getElementById('ingredientCost').value = String(ing.costo_por_unidad);
+      document.getElementById('ingredientDeleteBtn').disabled = false;
+      document.getElementById('ingredientMessage').textContent = '';
+    }
+
+    function clearIngredientForm() {
+      document.getElementById('ingredientForm').reset();
+      document.getElementById('ingredientId').value = '';
+      document.getElementById('ingredientDeleteBtn').disabled = true;
+      document.getElementById('ingredientMessage').textContent = '';
+    }
+
+    function handleIngredientFormSubmit(event) {
+      event.preventDefault();
+      const id = document.getElementById('ingredientId').value;
+      const nombre = document.getElementById('ingredientName').value.trim();
+      const unidad = document.getElementById('ingredientUnit').value.trim();
+      const costoStr = document.getElementById('ingredientCost').value;
+      const messageEl = document.getElementById('ingredientMessage');
+      messageEl.textContent = '';
+      if (!nombre) {
+        messageEl.textContent = 'El nombre es obligatorio';
+        return;
+      }
+      const costo = parseNumber(costoStr);
+      if (costo === null || costo < 0) {
+        messageEl.textContent = 'El costo debe ser un número mayor o igual a 0';
+        return;
+      }
+      const nameExists = state.ingredientes.some(
+        (ing) => ing.nombre.toLowerCase() === nombre.toLowerCase() && ing.id !== id
+      );
+      if (nameExists) {
+        messageEl.textContent = 'Ya existe un ingrediente con ese nombre';
+        return;
+      }
+      if (id) {
+        updateState({
+          ingredientes: state.ingredientes.map((ing) =>
+            ing.id === id ? { ...ing, nombre, unidad, costo_por_unidad: costo } : ing
+          )
+        });
+        showToast('Ingrediente actualizado');
+      } else {
+        const newIngredient = { id: uid(), nombre, unidad, costo_por_unidad: costo };
+        updateState({ ingredientes: [...state.ingredientes, newIngredient] });
+        showToast('Ingrediente agregado');
+      }
+      clearIngredientForm();
+    }
+
+    function deleteIngredient() {
+      const id = document.getElementById('ingredientId').value;
+      if (!id) return;
+      updateState({
+        ingredientes: state.ingredientes.filter((ing) => ing.id !== id),
+        productos: state.productos.map((prod) => ({
+          ...prod,
+          componentes: prod.componentes.filter((comp) => comp.ingrediente_id !== id)
+        }))
+      });
+      showToast('Ingrediente eliminado');
+      clearIngredientForm();
+    }
+
+    function createProduct() {
+      const newProduct = {
+        id: uid(),
+        nombre: 'Nuevo producto',
+        unidad_salida: 'u',
+        cantidad_salida: 1,
+        componentes: []
+      };
+      updateState({
+        productos: [...state.productos, newProduct],
+        seleccionado: { productoId: newProduct.id }
+      });
+      showToast('Producto creado');
+    }
+
+    function deleteSelectedProduct() {
+      const product = getSelectedProduct();
+      if (!product) return;
+      const remaining = state.productos.filter((p) => p.id !== product.id);
+      const nextSelection = remaining[0]?.id || null;
+      updateState({ productos: remaining, seleccionado: { productoId: nextSelection } });
+      showToast('Producto eliminado');
+    }
+
+    function duplicateSelectedProduct() {
+      const product = getSelectedProduct();
+      if (!product) return;
+      let baseName = `${product.nombre} (copia)`;
+      let uniqueName = baseName;
+      let counter = 2;
+      while (state.productos.some((p) => p.nombre === uniqueName)) {
+        uniqueName = `${baseName} ${counter++}`;
+      }
+      const duplicate = {
+        ...JSON.parse(JSON.stringify(product)),
+        id: uid(),
+        nombre: uniqueName
+      };
+      updateState({
+        productos: [...state.productos, duplicate],
+        seleccionado: { productoId: duplicate.id }
+      });
+      showToast('Producto duplicado');
+    }
+
+    function exportState() {
+      const data = JSON.stringify(state, null, 2);
+      const blob = new Blob([data], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'costos.json';
+      a.click();
+      URL.revokeObjectURL(url);
+    }
+
+    function importState(file) {
+      const reader = new FileReader();
+      reader.onload = (event) => {
+        try {
+          const parsed = JSON.parse(event.target.result);
+          if (!Array.isArray(parsed.ingredientes) || !Array.isArray(parsed.productos)) {
+            throw new Error('Formato inválido');
+          }
+          const confirmReplace = window.confirm('¿Reemplazar datos actuales?');
+          if (!confirmReplace) return;
+          state = {
+            ingredientes: parsed.ingredientes,
+            productos: parsed.productos,
+            seleccionado: parsed.seleccionado || { productoId: null }
+          };
+          scheduleSave();
+          render();
+          showToast('Datos importados correctamente');
+        } catch (error) {
+          console.error(error);
+          showToast('Archivo inválido', 'error');
+        }
+      };
+      reader.readAsText(file);
+    }
+
+    function resetState() {
+      const confirmReset = window.confirm('Esto borrará los datos actuales. ¿Continuar?');
+      if (!confirmReset) return;
+      state = JSON.parse(JSON.stringify(seed));
+      scheduleSave();
+      render();
+      showToast('Datos restablecidos');
+    }
+
+    function handleGlobalShortcuts(event) {
+      if (event.key === 'Escape') {
+        clearIngredientForm();
+        const componentForm = document.getElementById('componentForm');
+        if (componentForm) {
+          componentForm.reset();
+          document.getElementById('componentMessage').textContent = '';
+        }
+      }
+    }
+
+    function setupEvents() {
+      document.getElementById('productSearch').addEventListener('input', renderProductsList);
+      document.getElementById('newProductBtn').addEventListener('click', createProduct);
+      document.getElementById('deleteProductBtn').addEventListener('click', deleteSelectedProduct);
+      document.getElementById('duplicateProductBtn').addEventListener('click', duplicateSelectedProduct);
+
+      document.getElementById('ingredientForm').addEventListener('submit', handleIngredientFormSubmit);
+      document.getElementById('ingredientClearBtn').addEventListener('click', clearIngredientForm);
+      document.getElementById('ingredientDeleteBtn').addEventListener('click', deleteIngredient);
+      document.getElementById('ingredientForm').addEventListener('keydown', (event) => {
+        if (event.key === 'Escape') {
+          event.preventDefault();
+          clearIngredientForm();
+        }
+      });
+
+      document.getElementById('exportBtn').addEventListener('click', exportState);
+      document.getElementById('importInput').addEventListener('change', (event) => {
+        const [file] = event.target.files;
+        if (file) {
+          importState(file);
+        }
+        event.target.value = '';
+      });
+      document.getElementById('resetBtn').addEventListener('click', resetState);
+
+      document.addEventListener('keydown', handleGlobalShortcuts);
+
+      const mobileTabs = document.getElementById('mobileTabs');
+      mobileTabs.querySelectorAll('button').forEach((button) => {
+        button.addEventListener('click', () => {
+          mobileTabs.querySelectorAll('button').forEach((b) => b.classList.remove('active'));
+          button.classList.add('active');
+          const target = button.dataset.target;
+          document.querySelectorAll('.panel').forEach((panel) => {
+            panel.classList.toggle('active', panel.id === `${target}Panel`);
+          });
+        });
+      });
+    }
+
+    function ensureSelection() {
+      const current = state.seleccionado?.productoId;
+      if (current && state.productos.some((p) => p.id === current)) return;
+      const first = state.productos[0]?.id || null;
+      updateState({ seleccionado: { productoId: first } });
+    }
+
+    function render() {
+      ensureSelection();
+      renderProductsList();
+      renderProductDetail();
+      renderIngredients();
+      updateButtonsState();
+      updatePanelsForViewport();
+    }
+
+    function updateButtonsState() {
+      const hasSelection = Boolean(getSelectedProduct());
+      document.getElementById('deleteProductBtn').disabled = !hasSelection;
+      document.getElementById('duplicateProductBtn').disabled = !hasSelection;
+      const tag = document.getElementById('detalleTag');
+      tag.classList.toggle('muted', !hasSelection);
+    }
+
+    function updatePanelsForViewport() {
+      if (window.innerWidth <= 900) {
+        const activeTab = document.querySelector('.mobile-tabs button.active')?.dataset.target || 'productos';
+        document.querySelectorAll('.panel').forEach((panel) => {
+          panel.classList.toggle('active', panel.id === `${activeTab}Panel`);
+        });
+      } else {
+        document.querySelectorAll('.panel').forEach((panel) => panel.classList.add('active'));
+      }
+    }
+
+    window.addEventListener('resize', updatePanelsForViewport);
+
+    setupEvents();
+    render();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- build a single-page HTML application with responsive styling to manage products and ingredients and display cost metrics
- implement client-side state management with autosave, validation, and calculations for component costs and product duplication
- add JSON import/export/reset controls with toast feedback and keyboard shortcuts

## Testing
- No automated tests (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ebe95007788332847c3a3f8e5c32a1